### PR TITLE
Censor List for RebootTech Twitch

### DIFF
--- a/story/censored_words.txt
+++ b/story/censored_words.txt
@@ -1,114 +1,2339 @@
-BlowJob
-Clit
-Cock
-CockSucker
-Goddamned
-MothaFucker
-MothaFuker
-MothaFukkah
-MothaFukker
-MotherFucker
-MotherFukah
-MotherFuker
-MotherFukkah
-MotherFukker
-MuthaFucker
-MuthaFukah
-MuthaFuker
-MuthaFukkah
-MuthaFukker
-Shitty
-Shity
-anus
-ass
-asshole
-assholes
-assjob
-assrammer
-asswipe
-b1tch
-bastard
-bastards
-bitch
-bitches
-blowjob
-boobs
-bullshit
-butthole
-buttwipe
-clit
-clits
-cock
-cockhead
-cocks
-cocksucker
-cum
-cunt
-cunts
-damn
-dick
-dildo
-dildos
-ejackulate
-ejakulate
-fatass
-foreskin
-fuck
-fucka
-fucker
-fuckin
-fucking
-fucks
-fuk
-hell
-hells
-hentai
-jackoff
-jerkoff
-jizz
-masturbate
+your pants are being pulled down
+tell her to take off her clothes
+sexually transmitted infections
+hot sticky seed deep inside her
+finish her off with a spanking
+enjoy the feeling of his dick
+sudden infant death syndrome
+sandy hook elementary school
+release your load inside her
+burst forth from your vagina
+rosy palm and her 5 sisters
+feel the warmth of his dick
+epstein didn't kill himself
+shoot your load inside her
+continue to pound her face
+choke her until she passes
+writhes around in ecstasy
+to move around inside you
+she begins to moan loudly
+pump it in and out of her
+son of a motherless goat
+says "it feels so good!"
+puts it in her own mouth
+him panting and groaning
+beating up all the women
+two fingers with tongue
+to punch her repeatedly
+slowly moves inside you
+leather straight jacket
+kissed you passionately
+fuckingshitmotherfucker
+blonde on blonde action
+begins to touch himself
+begins to touch herself
+prince albert piercing
+nasal and sinus cancer
+move down to your body
+grab her by the throat
+pulls down his pants.
+kiss you passionately
+cock and ball torture
+beat up all the girls
+you massage her hips
+urban dictionary-ing
+run down your throat
+pulls down his pants
+pull your pants down
+pull out and push in
+pound her brains out
+grab her by the hair
+fills you completely
+filled with pleasure
+erectile dysfunction
+beating up the women
+beating up all women
+vaginal juices flow
+missionary position
+im rick james bitch
+explodes inside you
+beating up the girl
+american nazi party
+urban dick-tionary
+release inside you
+release inside him
+release inside her
+push it in and out
+pumping in and out
+explosive diarrhea
+double penetration
+concentration camp
+columbine shooting
+columbine shooters
+columbine massacre
+chocolate rosebuds
+bang \(one's\) box
+alabama hot pocket
+wrinkled starfish
+two girls one cup
+stroking yourself
+rubbing your skin
+releases his load
+release your load
+one cup two girls
+nuclear explosion
+licking her clean
+leather restraint
+her warm mouth on
+grind against you
+getting rock hard
+gasped and moaned
+flipping the bird
+cleveland steamer
+chicks with dicks
+chick with a dick
+beat up the women
+beat up the woman
+armenian genocide
+"That feels good"
+your load inside
+ur granny tranny
+terrorist attack
+sink your member
+she moans loudly
+punch her in the
+inject your seed
+he'll cum inside
+grinding herself
+finally pull out
+filled with eggs
+female squirting
+beating up women
+beat up the girl
+anorexia nervosa
+alaskan pipeline
+white privilege
+vaginal muscles
+timothy mcveigh
+taking the piss
+shove your dong
+shove your dick
+reverse cowgirl
+pump in and out
+prostate cancer
+pre-cum to leak
+osama bin laden
+one night stand
+one guy one jar
+moo moo foo foo
+into your mouth
+hot sticky seed
+hot sticky load
+grabs his penis
+girls gone wild
+force feminized
+eject your load
+brunette action
+attention whore
+yellow showers
+vaginal thrush
+vaginal juices
+vaginal cancer
+uyghur muslims
+suicide forest
+stretching you
+south carolina
+son-of-a-bitch
+son of a whore
+son of a bitch
+sink your fist
+sink your dong
+sink your dick
+sink your d1ck
+rusty trombone
+pleasure chest
+ovarian cancer
+north carolina
+myspace whores
+mound of venus
+motherfuckings
+menage a trois
+male squirting
+huge and thick
+genital herpes
+facebook whore
+dental abscess
+carpet muncher
+blow your load
+bladder cancer
+beaver cleaver
+acrotomophilia
+Carpet Muncher
+xxx-tentacion
+window licker
+whorealicious
+vacation dick
+uyghur muslim
+suicide girls
+splooge moose
+she pulls out
+shaved beaver
+sexual health
+sausage queen
+private parts
+pre-cum leaks
+piece of shit
+need the dick
+motherfucking
+motherfuckers
+mother-fucker
+mother fucker
+mothafuckings
+middle finger
+masterbations
+is riding you
+inside of her
+how to murder
+how to murdep
+he forces his
+golden shower
+genital warts
+gender bender
+fingerfucking
+fingerfuckers
+dirty sanchez
+dirty pillows
+dirty Sanchez
+dingleberries
+determination
+cop some wood
+coffin dodger
+clover clamps
+clitty litter
+charlie hebdo
+carpetmuncher
+brown showers
+brotherfucker
+breast cancer
+body painting
+blonde action
+beef curtains
+beat up women
+adult diapers
+She pulls out
+Mother Fukker
+Mother Fukkah
+Mother Fucker
+2 girls 1 cup
+wrapping men
+whoralicious
+white people
+watch online
+vorarephilia
+urethra play
+uncle fucker
+tittiefucker
+tainted love
+sumofabiatch
+sultry women
+shirt lifter
+shaved pussy
+reproductive
+raging boner
+pussypounder
+pussylicking
+pussy palace
+porch monkey
+penis-breath
+ovarian cyst
+off the hook
+niggerfaggot
+nigga please
+mutherfucker
+muthafuckker
+motherfuckka
+motherfuckin
 motherfucker
-negro
-nigga
-niggas
-nigger
-niggr
-nigur
-niiger
-niigr
-nutsack
-orgasm
-penis
-pussy
-rectum
-scrotum
-semen
-sex
-sexy
-shit
-shits
-shitting
-shitted
-slut
-slutty
-stripper
-testical
-testicle
-tit
-tits
-titt
+motherfucked
+mothafucking
+mothafuckers
+microphallus
+menstruation
+masturbation
+masturbating
+masterbation
+masterbating
+masterbaiter
+make me come
+ku klux klan
+jungle bunny
+in her pants
+iberian slap
+homodumbshit
+grammar nazi
+goldenshower
+giant member
+fudge-packer
+fudge packer
+fuckersucker
+fuck yo mama
+fuck buttons
+flog the log
+fistfuckings
+fingerfucker
+fingerfucked
+ejaculatings
+eat hair pie
+douchewaffle
+donkeyribber
+donkey punch
+dominatricks
+doggie-style
+doggie style
+dendrophilia
+dawgie-style
+cyberfucking
+cyberfuckers
+cum dumpster
+cockmongruel
+child-fucker
+bunny fucker
+bowel cancer
+boku no pico
+blackmailing
+binge eating
+big knockers
+beef curtain
+barely legal
+ball sucking
+ball licking
+ball kicking
+anal leakage
+anal impaler
+adult diaper
+adolf hitler
+Mutha Fukker
+Mutha Fukkah
+Mutha Fucker
+MotherFukker
+MotherFukkah
+MotherFucker
+Mother Fuker
+Mother Fukah
+Motha Fukker
+Motha Fukkah
+Motha Fucker
+Fudge Packer
+your member
+whorehopper
+white trash
+white pride
+white power
+violet wand
+venus mound
+unclefucker
+two fingers
+transsexual
+tongue in a
+tittyfucker
+tight white
+thundercunt
+telecharger
+tea bagging
+style doggy
+spread legs
+snowballing
+slut bucket
+shitspitter
+shit fucker
+sand nigger
+prostitutes
+prickteaser
+pornography
+porchmonkey
+pole smoker
+pillowbiter
+penispuffer
+penisfucker
+penisbanger
+penetration
+pedophiliac
+nymphomania
+nsfw images
+ninnyhammer
+nimphomania
+nigger rich
+new zealand
+needle dick
+necrophilia
+muthafecker
+motherfucks
+motherfucka
+mothafuckin
+mothafucker
+mothafucked
+mothafuckaz
+mothafuckas
+masterbates
+master-bate
+massterbait
+lung cancer
+lezza/lesbo
+lemon party
+junglebunny
+jelly donut
+jacking off
+intercourse
+impregnates
+how to kill
+hardcoresex
+girl on top
+gang member
+fudgepacker
+fuck trophy
+fuck puppet
+fuck a duck
+foot fetish
+fistfucking
+fistfuckers
+fingerfucks
+fartknocker
+fannyfucker
+fannybandit
+f u c k e r
+ejaculation
+ejaculating
+double dong
+donkeypunch
+dominatrics
+doggy-style
+doggy style
+doggiestyle
+dingleberry
+dickwhipper
+dicktickler
+dicksucking
+dickflipper
+dickbeaters
+dick-sneeze
+dick cheney
+deep throat
+cyberfucker
+cyberfucked
+cuntlicking
+cunt-struck
+cunnilingus
+cunillingus
+cumdumpster
+cum guzzler
+cum chugger
+coprophilia
+coprolagnia
+cocksucking
+cocksuckers
+cocksniffer
+cockmuncher
+cockmongler
+cockknocker
+cockholster
+cock-sucker
+cock sucker
+cock pocket
+clusterfuck
+clit licker
+chi-chi man
+cannabutter
+butt-pirate
+bust a load
+bullshitted
+bullet vibe
+blue waffle
+bloody hell
+blackmailed
+big breasts
+beaver lips
+beastiality
+beardedclam
+basic bitch
+baby batter
+auto erotic
+anal cancer
+amanda todd
+afghanistan
+MuthaFukker
+MuthaFukkah
+MuthaFucker
+Mutha Fuker
+Mutha Fukah
+MotherFuker
+MotherFukah
+MothaFukker
+MothaFukkah
+MothaFucker
+Motha Fuker
+you stroke
+yoga pants
+xbox nigga
+whorehouse
+white girl
+watch free
+war crimes
+vaffanculo
+urban dick
+undressing
+twatwaffle
+terrorists
+teabagging
+suplex her
+strip club
+spierdalaj
+smartasses
+slutdumper
+shitcanned
+shitbreath
+shitbrains
+shitbagger
+shit heads
+sex worker
+scissoring
+sandnigger
+rumprammer
+repeatedly
+rautenberg
+pussy fart
+prostitute
+poop chute
+polesmoker
+pittsburgh
+pissed off
+perversion
+pedophilia
+peckerhead
+paedophile
+p.u.s.s.y.
+nut butter
+nepesaurio
+muffdiving
+muff diver
+motherfuck
+mothafucks
+mothafucka
+mocha uson
+milfhunter
+menstruate
+masturbate
+masterbate
+masterbat3
+masstrbate
+masstrbait
+ma5terbate
+m45terbate
+lovemaking
+kunilingus
+homoerotic
+his member
+having sex
+god-damned
+giant cock
+gayfuckist
+gangbanged
+fucknugget
+fuckbutter
+fuck-buddy
+fuck-bitch
+front butt
+force your
+fleshflute
+fistfucker
+fistfucked
+fingerfuck
+fingerbang
+fannyflaps
+faggotcock
+ejaculates
+ejaculated
+ejackulate
+eating out
+eat my ass
+eat a dick
+douchebags
+douche-fag
+dominatrix
+domination
+doggystyle
+dog-fucker
+dickzipper
+dickweasel
+dicksucker
+dicksipper
+dickripper
+dickmonger
+dickfucker
+dickdipper
+delivering
+deepthroat
+cuntlicker
+cunthunter
+cunilingus
+cumguzzler
+crackwhore
+corp whore
+corksucker
+cokmuncher
+cockwaffle
+cocksucker
+cocksucked
+cocksmoker
+cocknugget
+cockmonkey
+cockmaster
+cockknoker
+cockjockey
+cockfucker
+cockburger
+cock block
+coccydynia
+circlejerk
+chota bags
+c0cksucker
+buttfucker
+buttcheeks
+bumblefuck
+booty call
+booooooobs
+boko haram
+body paint
+blue balls
+bloodclaat
+black cock
+bestiality
+bare naked
+ball gravy
+baby juice
+autoerotic
+assmuncher
+asscracker
+ass-pirate
+ass-jabber
+ass-fucker
+allegation
+abu obeida
+Poopuncher
+MuthaFuker
+MuthaFukah
+MothaFuker
+God-damned
+Doublelift
+CockSucker
+Ass Monkey
+zoophilia
+witnesses
+wiseasses
+whoreface
+wh0reface
+wet dream
+virginity
+violently
+vibrators
+varieties
+urophilia
+tribadism
+towelhead
+tittywank
+tittyfuck
+throating
+threesome
+testicles
+terrorist
+terrorism
+swamp ass
+strappado
+squirting
+spokesman
+sphencter
+skurwysyn
+skullfuck
+shrimping
+shittings
+shittiest
+shitstain
+shithouse
+shitheads
+shitfaced
+shiteater
+shitblimp
+she moans
+shamedame
+sexuality
+secretary
+rosy palm
+queerhole
+queerbait
+poopchute
+poop dick
+pissflaps
+pigfucker
+phone sex
+perverted
+penetrate
+peeenusss
+pedophile
+pantyhose
+octopussy
+nob jokey
+muffdiver
+muff puff
+mount you
+mouliewop
+mothafuck
+monkleigh
+masturbat
+masterbat
+masochist
+marijuana
+man whore
+m-fucking
+knobjokey
+knobjocky
+jiggerboo
+jail bait
+jackasses
+hot chick
+holy shit
+hircismus
+hard core
+group sex
+goddamnit
+goddamned
+goddammit
+gassy ass
+gangbangs
+gang-bang
+gang bang
+futkretzn
+fucktards
+fuckstick
+fuckin' a
+fuckheads
+fuckbrain
+fuck-tard
+fuck hole
+frenchify
+foreskins
+fistfucks
+fist fuck
+fingering
+feminized
+feminists
+fagfucker
+exploited
+execution
+employees
+ejakulate
+ejaculate
+dumbasses
+dp action
+douchebag
+dog style
+disorders
+dickjuice
+dickheads
+dick hole
+dick head
+dead body
+date rape
+czn burak
+cyberfuck
+cuntsicle
+cunt hair
+cumjockey
+cumbubble
+cum freak
+cremation
+crackhead
+corpulent
+committed
+columbine
+cocksukka
+cocksucks
+cocksmoke
+cocksmith
+cockmunch
+cockblock
+cock-head
+cock snot
+climaxing
+civil war
+chesticle
+camel toe
+cacafuego
+buttmunch
+buttfucka
+butt plug
+butt fuck
+bung hole
+bullturds
+bullshits
+bull shit
+blackmail
+bitchtits
+bitch tit
+big black
+best gore
+bescumber
+batty boy
+bastinado
+bassterds
+barenaked
+ball sack
+asssucker
+assrammer
+asspirate
+assnigger
+assmonkey
+assmaster
+asslicker
+assjacker
+asshopper
+assgoblin
+assfucker
+assbanger
+assbanged
+assbandit
+arschloch
+anilingus
+analprobe
+activated
+abortions
+Goddamned
+zabourah
+you moan
+whorebag
+violence
+vibrator
+veqtable
+vajayjay
 underage
-vag1na
-vagiina
-vagina
-vaj1na
-vajina
-vucking
-whore
-xrated
-xxx
-rape
-rimjob
+twatlips
+twathead
+tub girl
+tit wank
+testicle
+testical
+taste my
+swastika
+succubus
+stripper
+strictly
+strap on
+spanking
+sodomize
+smartass
+slutkiss
+slanteye
 shitting
-raped
+shittier
+shitters
+shitings
+shithole
+shithead
+shitfull
+shitfuck
+shitface
+shitdick
+shitcunt
+shit ass
+shemales
+sharmute
+sharmuta
+shagging
+sexually
+sex work
+screwing
+schlampe
+schaffer
+scantily
+santorum
+s.h.i.t.
+rohypnol
+retarted
+retarded
+referral
+race war
+poontsee
+poontang
+ponyplay
+piss-off
+piss pig
+piss off
+phukking
+phonesex
+perverts
+pedobear
+orgasmic
+orgasims
+orgasim;
+oral sex
+omorashi
+nut sack
+numbnuts
+nobjokey
+nobjocky
+neo-nazi
+mr hands
+molester
+mistress
+mcfagget
+masterb8
+masokist
+ma5terb8
+liveleak
+lesbians
+kuksuger
+knobhead
+knobbing
+knob end
+klootzak
+kinkster
+jiggaboo
+jerk-off
+jerk off
+jailbait
+jackhole
+jack-off
+jack off
+huge fat
+hot carl
+horniest
+holohoax
+he moans
+hardcore
+handjobs
+hand job
+ham flap
+goregasm
+goodpoop
+goo girl
+golliwog
+godsdamn
+godamnit
+god damn
+genocide
+genitals
+gangbang
+futanari
+fuckwitt
+fuckwhit
+fucktwat
+fucktart
+fucktard
+fucknutt
+fuckmeat
+fuckings
+fuckhole
+fuckhead
+fuckgirl
+fuckface
+fuckedup
+fuckbutt
+fuck-ass
+fuck you
+fuck off
+fuck her
+fuck ass
+frotting
+foreskin
+flexible
+fistfuck
+fingered
+fetishes
+feminist
+feminism
+feltcher
+fellatio
+felching
+executed
+essohbee
+erection
+ear rape
+dumbshit
+dumbfuck
+dumb ass
+dry hump
+doochbag
+dillweed
+dickweed
+dickslap
+dickmilk
+dickhole
+dickhead
+dickfuck
+dickface
+dick-ish
+dick shy
+diarrhea
+delivery
+daterape
+cyberfuc
+cut rope
+cuntslut
+cuntlick
+cunthole
+cuntface
+cumstain
+cumshots
+creampie
+cornhole
+coonnass
+contains
+coksucka
+cocksuka
+cocksuck
+cockshit
+cocknose
+cockhead
+cockface
+cockbite
+clitorus
+clitoris
+clitfuck
+clitface
+cleavage
+cinnamon
+choc ice
+censored
+cemetery
+camwhore
+cameltoe
+c.o.c.k.
+buttwipe
+buttplug
+buttmuch
+butthole
+buttfuck
+bunghole
+buncombe
+bullying
+bullshit
+bulldyke
+brunette
+breeding
+booooobs
+bollocks
+bodysuit
+body art
+blumpkin
+blowjobs
+blow mud
+blow job
+bitching
+bitchers
+bitchass
+birdlock
+big tits
+beeyotch
+beat her
+beastial
+basterdz
+basterds
+bastardz
+bastards
+bastardo
+bareback
+bangbros
+ballsack
+ball gag
+babeland
+asswipes
+asswhole
+assshole
+assmunch
+assmucus
+assholes
+assh0lez
+assfukka
+assfaces
+assclown
+assbangs
+ass hole
+ass fuck
+arsehole
+andskota
+anal sex
+al-qaida
+al-qaeda
+al qaida
+al qaeda
+adultery
+abortion
+Lipshitz
+Lipshits
+God damn
+Fuck off
+Dumbcunt
+Cocklump
+Blow Job
+x-rated
+wounded
+wiseass
+willies
+wichser
+whoring
+wetback
+wankjob
+vucking
+vjayjay
+victims
+vaginal
+vagiina
+va1jina
+upskirt
+twunter
+twinkie
+tubgirl
+trumped
+torture
+topless
+titwank
+titties
+tittie5
+titfuck
+tied up
+t1tties
+t1tt1e5
+swinger
+surfing
+suicide
+sucking
+suckass
+striped
+strapon
+splooge
+sod off
+slutbag
+skankey
+skankee
+shut in
+shrooms
+shiznit
+shitter
+shitted
+shiting
+shitbag
+shitass
+shibari
+shemale
+shaggin
+shagger
+sh1tter
+sexting
+seduced
+scrotum
+screwed
+schmuck
+schlong
+scheiss
+sandbar
+s_h_i_t
+s-h-i-t
+s-h-1-t
+rule 34
+rubbish
+roofies
+romance
+rimming
+request
+removal
+reetard
+redneck
+recktum
+raghead
+pussies
+punkass
+punanny
+preteen
+pre-cum
+pornhub
+poonany
+poonani
+pollock
+playboy
+pisspig
+pissoff
+pissing
+pissers
+pierdol
+phukked
+phuking
+phallic
+pervert
+pegging
+peeenus
+panties
+panooch
+orifiss
+orifice
+oriface
+orgasum
+orgasms
+orgasim
+old bag
+nutsack
+nobhead
+nipples
+niiger;
+niggers
+nigger;
+nigaboo
+nig-nog
+nig nog
+neonazi
+nawashi
+naggers
+munging
+mamhoon
+mafugly
+lusting
+lustful
+lolicon
+livesex
+licking
+lesbian
+lardass
+lameass
+kumming
+kooches
+kondums
+knobend
+knobead
+kinbaku
+jigaboo
+jerkoff
+jerkass
+jerk0ff
+jackoff
+jackass
+humping
+hooters
+hookers
+helvete
+hard on
+handjob
+goddamn
+god-dam
+girl on
+gestapo
+genital
+gaytard
+gaylord
+gaygirl
+gayfuck
+gay sex
+fukwhit
+fukkers
+fuckwit
+fuckwad
+fucktoy
+fuckoff
+fucknut
+fucking
+fuckers
+fuckboy
+fuckbag
+fuckass
+fuck up
+fuck it
+footjob
+fondled
+fisting
+figging
+females
+fellate
+felcher
+fcuking
+farting
+fapping
+fanculo
+fagtard
+faggots
+faggitt
+fagging
+f_u_c_k
+f.u.c.k
+f-u-c-k
+f u c k
+escorts
+erotism
+erotica
+epstein
+enculer
+ecstasy
+dumshit
+dumbass
+douchey
+dolcett
+dogging
+dipshit
+dipship
+dilld0s
+diligaf
+dickwod
+dickwad
+dickish
+dickbag
+desired
+depress
+cuntrag
+cuntbag
+cuntass
+cumtart
+cumslut
+cumshot
+cumming
+cumdump
+cuckold
+cruelty
+cripple
+cracker
+coochie
+condoms
+cockeye
+cockass
+cocaine
+camslut
+camgirl
+c.u.n.t
+c.0.c.k
+c-u-n-t
+c-o-c-k
+c-0-c-k
+buttsex
+bumclat
+bum boy
+bulimia
+bukkake
+breasts
+boooobs
+boobies
+bondage
+bombing
+bollock
+boiolas
+boffing
+blowjob
+blow me
+bitcoin
+bitchin
+bitches
+bitcher
+bitched
+bigtits
+bestial
+bellend
+beaners
+bastard
+bangbus
+ballbag
+baghdad
+azzhole
+axwound
+asswipe
+assshit
+asslick
+assholz
+asshole
+assho1e
+asshead
+assh0le
+assfuck
+assface
+asscock
+assbite
+assbang
+assault
+ass-hat
+asholes
+ash0les
+aroused
+apeshit
+accused
+abusive
+abusing
+a55hole
+a$$hole
+Sandler
+Poonani
+Phukker
+Lezzian
+Lesbian
+Goddamn
+Flikker
+Felcher
+Breeder
+BlowJob
+Assface
+A.I.D.S
+zainab
+yeasty
+xrated
+x-bomb
+wigger
+whores
+whored
+whitey
+weirdo
+weiner
+weewee
+weenie
+wedgie
+wanker
+vullva
+vulgar
+voyeur
+virgin
+viagra
+vbucks
+valium
+vajina
+vaj1na
+vagina
+vag1na
+va-j-j
+v14gra
+uterus
+urinal
+undies
+twinks
+twatty
+trashy
+tranny
+tosser
+tittie
+titten
+tities
+tinkle
+thrust
+testis
+testes
+testee
+ted fu
+tawdry
+tampon
+sucked
+stupid
+stroke
+stoned
+stiffy
+spooge
+soused
+sodomy
+sniper
+snatch
+smutty
+smegma
+slutty
+sleazy
+sleaze
+slaves
+skribz
+skanks
+skanck
+shitty
+shitey
+shited
+shipal
+sh1ter
+sexual
+sexcam
+seduce
+seamen
+seaman
+scrote
+scroat
+schizo
+sanger
+salvia
+sadist
+sadism
+saddam
+s.o.b.
+rufies
+ritard
+rimjob
+rimjaw
+retard
+reefer
+rectus
+rectum
+rectal
+raunch
+rapist
 raping
+racist
+racism
+r-tard
+qweerz
+qweers
+quicky
+queerz
+queers
+queero
+qahbeh
+puuker
+pussys
+pussie
+pussee
+punany
+punani
+psycho
+pricks
+pornos
+polack
+pissin
+pisses
+pisser
+pissed
+pimpis
+pimmel
+phuked
+penuus
+penile
+penial
+peinus
+peepee
+peenus
+peeing
+pecker
+pantie
+packie
+orospu
+orgies
+orgasm
+orally
+orafis
+opiate
+nympho
+nutter
+nutten
+nudity
+nudist
+nipple
+nimrod
+niigr;
+niiger
+nigur;
+niglet
+niggle
+nigger
+niggaz
+niggas
+niggah
+nigg4h
+nigg3r
+nazism
+napalm
+nambla
+n1gger
+n word
+muther
+muschi
+murder
+munter
+mulkku
+moolie
+molest
+minger
+midget
+menses
+mature
+mating
+looney
+lolita
+lezzie
+lesbos
+l3itch
+l3i+ch
+kummer
+kootch
+kondum
+knulle
+knobed
+kanker
+junkie
+jizzed
+jerked
+jagoff
+incest
+inbred
+humped
+hotsex
+horney
+hooter
+hootch
+hooker
+hookah
+honkey
+homoey
+hitler
+hetero
+herpes
+heroin
+hentai
+he-she
+harass
+guiena
+gringo
+gonads
+gokkun
+goddam
+godamn
+goatse
+goatcx
+ginger
+gigolo
+gaywad
+gaysex
+gayboy
+gaybob
+gayass
+g-spot
+g spot
+fukwit
+fukkin
+fukker
+fuckup
+fuckme
+fuckin
+fucker
+fucked
+frigga
+freaky
+fraser
+forced
+fooker
+foobar
+fondle
+floozy
+flange
+flamer
+fisted
+ficken
+fetish
+fenian
+femdom
+feltch
+fecker
+fcuker
+fatass
+fagots
+faggot
+faggit
+fagged
+fagg1t
+fagbag
+facial
+extasy
+extacy
+eunuch
+erotic
+earwax
+dziwka
+dumass
+dommes
+doggin
+dingle
+dimwit
+dilld0
+dildos
+dild0s
+diddle
+deaths
+darkie
+damnit
+damned
+dammit
+d0uche
+d0uch3
+cyalis
+cunnie
+cummin
+cummer
+crotte
+crotch
+cooter
+coochy
+condom
+commie
+coital
+cocain
+clunge
+clitty
+climax
+chodes
+choade
+chinky
+chincs
+cervix
+cahone
+cabron
+buried
+bummer
+bulges
+bugger
+buceta
+brutal
+brooke
+breeds
+breast
+bosomy
+boozer
+bootie
+bootee
+booobs
+bookie
+booger
+boners
+bombed
+bollox
+bollok
+bodily
+blonde
+blacks
+bitchy
+bimbos
+biatch
+beotch
+bender
+beaver
+beater
+beatch
+beaner
+banged
+bampot
+azazel
+autism
+asswad
+assjob
+asshat
+assbag
+ash0le
+areole
+areola
+antifa
+aeolus
+adults
+abuser
+Slutty
+Skanky
+Shytty
+Shitty
+Phuker
+Huevon
+Fukkin
+Fukker
+Fukken
+Fukkah
+Biatch
+11-sep
+#metoo
+zibbi
+yobbo
+yiffy
+xtube
+willy
+whore
+whoar
+wh0re
+wh00r
+wench
+welsh
+wazoo
+wanky
+w00se
+vulva
+vodka
+vixen
+vittu
+v1gra
+urine
+unwed
+twunt
+twink
+twerk
+twats
+tushy
+tramp
+toots
+titty
+thong
+thick
+teste
+teets
+t bag
+syria
+strip
+spunk
+spook
+spiks
+spick
+sperm
+spank
+souse
+sodom
+snuff
+slutz
+sluts
+slope
+slave
+skeet
+skank
+sissy
+simon
+shota
+shitz
+shitt
+shits
+shite
+sh1tz
+sh1ts
+semen
+scrud
+scrot
+scrog
+screw
+scank
+sambo
+sadly
+s-o-b
+s hit
+ruski
+rtard
+revue
+renob
+reich
+rapey
+raper
+raped
+qweir
+queer
+queef
+queaf
+qanon
+puuke
+pussy
+pussi
+pusse
+punta
+punky
+pubis
+pubic
+pubes
+prude
+prick
+pr1ck
+potty
+porno
+poops
+polak
+polac
+pizda
+pinko
+pillu
+pikey
+picka
+phuks
+phuck
+perse
+penus
+penis
+penas
+pen1s
+paska
+papua
+panty
+pansy
+pakie
+paedo
+packy
+packi
+ovums
+ovary
+osama
+organ
+nonce
+nofap
+ninny
+niigr
+nigur
+niggr
+nigga
+negro
+nazis
+nastt
+nappy
+naked
+n1gga
+mutha
+moron
+mo-fo
+minge
+milfs
+mibun
+mgtow
+massa
+lusty
+loins
+lesbo
+labia
+kyrpa
+kyler
+kurwa
+kuntz
+kunts
+kunja
+kraut
+kooch
+knobz
+knobs
+kinky
+kikes
+kafir
+junky
+juggs
+jisim
+jaggi
+injun
+hymen
+hussy
+horny
+hoore
+hooch
+honky
+hobag
+hoare
+heshe
+herpy
+guido
+gspot
+grope
+gooks
+gooch
+gonad
+glans
+gippo
+gaydo
+ganja
+fux0r
+fuker
+fucks
+fucka
+freex
+fisty
+felch
+feist
+feces
+fecal
+farts
+fanyy
+fanny
+fails
+faigt
+faigs
+fagot
+fagit
+faggs
+faget
+fag1t
+f4nny
+erect
+ecchi
+dykes
+duche
+drunk
+dopey
+doosh
+dirsa
+dinks
+dildo
+dild0
+dicks
+delhi
+deggo
+death
+daygo
+dagos
+d1ldo
+d1ld0
+cuntz
+cunts
+cunny
+cruel
+crips
+crack
+crabs
+corps
+coons
+cocks
+clits
+chraa
+chode
+choad
+chink
+chinc
+cazzo
+cawks
+c0cks
+butts
+busty
+bulge
+bucks
+bosom
+boozy
+booze
+booty
+boong
+booby
+boobs
+boner
+boned
+boink
+bitch
+bimbo
+bi7ch
+bi+ch
+bawdy
+balls
+b1tch
+b17ch
+b00bs
+b!tch
+b!+ch
+aunty
+asses
+aryan
+arrse
+arian
+amcik
+ahole
+adolf
+abuse
+a_s_s
+Shyty
+Shyte
+Shity
+Phuck
+Kurac
+Fukin
+Fuken
+Fukah
+Fotze
+Ekrem
+4chan
+14/88
+zubb
+yiff
+yaoi
+xnxx
+womb
+whiz
+weed
+wank
+wang
+vore
+twat
+tw4t
+tush
+turk
+turd
+toke
+todd
+titt
+tits
+titi
+thug
+teez
+teat
+tart
+tard
+taig
+taff
+suka
+suck
+spik
+spic
+spac
+smut
+smeg
+slut
+slag
+skag
+shut
+shiz
+shit
+shi+
+shag
+sh1t
+sh!t
+sh!+
+sexy
+sext
+sexo
+seks
+scum
+scat
+scag
+rump
+roms
+rape
+racy
+quim
+puto
+puta
+pust
+puss
+pule
+pula
+pube
+pthc
+pron
+prod
+prig
+pr1k
+pr1c
+pr0n
+porn
+poop
+poon
+piss
+pimp
+phuq
+phuk
+pedo
+pawn
+paky
+paki
+p0rn
+ovum
+orgy
+oral
+nude
+nsfw
+nazi
+n1gr
+muie
+muff
+mong
+momo
+mofo
+mof0
+milf
+mick
+merd
+maxi
+mams
+m0fo
+m0f0
+lust
+lube
+loin
+lech
+kyke
+kwif
+kusi
+kunt
+kums
+kock
+knob
+klan
+kike
+kawk
+jock
+jizz
+jizm
+jiss
+jism
+jews
+jerk
+japs
+jada
+isis
+hump
+hore
+hoor
+homo
+hom0
+hoer
+hoar
+hemp
+heeb
+hebe
+he11
+h0re
+h0mo
+h0m0
+h0ar
+h00r
+guro
+gtfo
+gook
+gilf
+ghey
+ghay
+gayz
+gays
+g00k
+fxck
+fvck
+fuks
+fuck
+fook
+foah
+foad
+fice
+feck
+fcuk
+fart
+faig
+fagz
+fags
+fagg
+faen
+fack
+dyke
+dvda
+dupa
+dong
+dlck
+dink
+dike
+dick
+dego
+dago
+d4mn
+d1ck
+d0ng
+cyst
+cunt
+cums
+cuck
+coon
+cock
+cnut
+cntz
+cnts
+clit
+cl1t
+cipa
+chuj
+cawk
+caca
+c0ck
+butt
+bung
+boob
+bong
+bomb
+blow
+bint
+bdsm
+barf
+b00b
+ayir
+arse
+ar5e
+anus
+anal
+aids
+acne
+Shyt
+Sh!t
+Phuk
+Phuc
+Fukk
+Fu\(
+Ekto
+Cock
+Clit
+AIDS
+5hit
+5h1t
+4r5e
+2g1c
+yid
+yed
+xxx
+wtf
+wop
+wog
+wad
+w0p
+vag
+uzi
+tue
+tit
+t1t
+sex
+s0b
+s&m
+rum
+r18
+pot
+pms
+pee
+pcp
+par
+nut
+nug
+nob
+lez
+kum
+kuk
+kkk
+jiz
+jap
+iap
+hun
+hui
+hoe
+hiv
+h0r
+git
+gfy
+gey
+gay
+gai
+gae
+fux
+fuq
+fuk
+fuc
+feg
+fap
+fag
+div
+cus
+cum
+cox
+cok
+c0k
+bum
+bra
+bod
+bbw
+azz
+ass
+a55
+a54
+a2m
+a$$
+LEN
+@$$
+911
+18+
+xx
+ui
+ho
+cp
+bl
+af
+88


### PR DESCRIPTION
I ran AIDungeonII successfully on Twitch without getting banned.   I did this mostly by blocking the ways people normally prompt the model for Adult content *and* blocking common adult content output from the Model.  The censor list that keeps AIDungeon from getting banned on Twitch.  Bear in mind that you must censor both input to the model and output.  If you fail to censor the input, people can still prompt it badly.

## 🎉 Issues resolved:

- closes #

## 🧪 How to Test

1. Do this
2. Then this



## 📷 Screenshot (optional)
There are hours and hours of videos. 
https://www.twitch.tv/videos/534221888  
 https://www.twitch.tv/reboottech/videos 

